### PR TITLE
fix: Add Refresh Ahead Caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "check": "tsc --noEmit",
+    "prepare": "./scripts/prepare-effect.sh",
     "format": "prettier --write .",
     "migration:generate": "drizzle-kit generate",
     "migration:migrate": "drizzle-kit migrate",

--- a/scripts/prepare-effect.sh
+++ b/scripts/prepare-effect.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -eu
+
+repo_dir=".repos/effect"
+repo_url="https://github.com/Effect-TS/effect"
+
+if [ -d "$repo_dir/.git" ]; then
+  exit 0
+fi
+
+mkdir -p ".repos"
+git clone "$repo_url" "$repo_dir"

--- a/src/api/routers/audio_assets.ts
+++ b/src/api/routers/audio_assets.ts
@@ -7,9 +7,7 @@ import { PROJECT_S3_ALIAS } from '~/constants';
 import { AiProvider, VoiceTypeEnum, type VoiceType } from '~/effect/ai';
 import { ObjectStorage } from '~/effect/storage';
 import { Database } from '~/effect/database';
-import { BackgroundWork } from '~/effect/background';
-import { CACHE } from '~/effect/cache';
-import { appRuntime } from '~/effect/runtime';
+import { CACHE, invalidateAndRefreshCache } from '~/effect/cache';
 import { DatabaseError } from '~/effect/errors';
 import { t, protectedAdminProcedure } from '../trpc_init';
 import { runTrpcEffect } from '~/effect/run';
@@ -86,7 +84,6 @@ export const uploadAudioAsset = Effect.fn('uploadAudioAsset')(function* (input: 
 export const deleteAudioAsset = Effect.fn('deleteAudioAsset')(function* (input: { id: number }) {
   const database = yield* Database;
   const storage = yield* ObjectStorage;
-  const background = yield* BackgroundWork;
 
   const result = yield* database.run('find_audio_asset', async (db) =>
     db.query.audio_assets.findFirst({
@@ -141,21 +138,21 @@ export const deleteAudioAsset = Effect.fn('deleteAudioAsset')(function* (input: 
   result.words.forEach((word) => lesson_ids.add(word.lesson.id));
 
   if (lesson_ids.size > 0) {
-    const refresh = Effect.forEach(
+    yield* Effect.forEach(
       Array.from(lesson_ids),
       (lesson_id) =>
-        CACHE.lessons.text_lesson_info
-          .refresh({ lesson_id })
-          .pipe(
-            Effect.catch((error) =>
-              Effect.logWarning('lesson cache refresh failed', { lesson_id, error }).pipe(
-                Effect.asVoid
-              )
+        invalidateAndRefreshCache({
+          cache: CACHE.lessons.text_lesson_info,
+          params: { lesson_id }
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning('lesson cache refresh failed', { lesson_id, error }).pipe(
+              Effect.asVoid
             )
-          ),
+          )
+        ),
       { concurrency: 4 }
     );
-    yield* background.enqueue(() => appRuntime.runPromise(refresh));
   }
 
   return { deleted: true as const };

--- a/src/api/routers/image_assets.ts
+++ b/src/api/routers/image_assets.ts
@@ -11,9 +11,7 @@ import { AiProvider } from '~/effect/ai';
 import { ImageProcessor } from '~/effect/image';
 import { ObjectStorage } from '~/effect/storage';
 import { Database } from '~/effect/database';
-import { BackgroundWork } from '~/effect/background';
-import { CACHE } from '~/effect/cache';
-import { appRuntime } from '~/effect/runtime';
+import { CACHE, invalidateAndRefreshCache } from '~/effect/cache';
 import { BadRequestError, DatabaseError } from '~/effect/errors';
 
 const IMAGE_DIMENSIONS = 256;
@@ -130,7 +128,6 @@ export const makeUploadImageAsset = Effect.fn('makeUploadImageAsset')(function* 
 export const deleteImageAsset = Effect.fn('deleteImageAsset')(function* (input: { id: number }) {
   const database = yield* Database;
   const storage = yield* ObjectStorage;
-  const background = yield* BackgroundWork;
 
   const result = yield* database.run('find_image_asset', async (db) =>
     db.query.image_assets.findFirst({
@@ -178,21 +175,21 @@ export const deleteImageAsset = Effect.fn('deleteImageAsset')(function* (input: 
   result.words.forEach((word) => lesson_ids.add(word.lesson.id));
 
   if (lesson_ids.size > 0) {
-    const refresh = Effect.forEach(
+    yield* Effect.forEach(
       Array.from(lesson_ids),
       (lesson_id) =>
-        CACHE.lessons.text_lesson_info
-          .refresh({ lesson_id })
-          .pipe(
-            Effect.catch((error) =>
-              Effect.logWarning('lesson cache refresh failed', { lesson_id, error }).pipe(
-                Effect.asVoid
-              )
+        invalidateAndRefreshCache({
+          cache: CACHE.lessons.text_lesson_info,
+          params: { lesson_id }
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning('lesson cache refresh failed', { lesson_id, error }).pipe(
+              Effect.asVoid
             )
-          ),
+          )
+        ),
       { concurrency: 8 }
     );
-    yield* background.enqueue(() => appRuntime.runPromise(refresh));
   }
 
   return { deleted: true as const };

--- a/src/api/routers/lesson_categories.ts
+++ b/src/api/routers/lesson_categories.ts
@@ -3,9 +3,7 @@ import { and, eq, max, sql } from 'drizzle-orm';
 import { Effect } from 'effect';
 import { lesson_categories, text_lessons } from '~/db/schema';
 import { dbRun, dbTransaction, type DbTransaction } from '~/effect/database';
-import { CACHE } from '~/effect/cache';
-import { BackgroundWork } from '~/effect/background';
-import { appRuntime } from '~/effect/runtime';
+import { CACHE, invalidateAndRefreshCache } from '~/effect/cache';
 import { t, protectedAdminProcedure, publicProcedure } from '~/api/trpc_init';
 import { runTrpcEffect } from '~/effect/run';
 import { LessonCategoriesSchemaZod, TextLessonsSchemaZod } from '~/db/schema_zod';
@@ -161,7 +159,6 @@ export const updateTextLessonsOrder = Effect.fn('updateTextLessonsOrder')(functi
   lessons: Array<{ id: number; order: number | null }>;
   category_id: number;
 }) {
-  const background = yield* BackgroundWork;
   yield* dbTransaction('update_text_lessons_order', async (tx) => {
     if (input.lessons.length === 0) return;
     const value_rows = input.lessons.map(
@@ -175,11 +172,10 @@ export const updateTextLessonsOrder = Effect.fn('updateTextLessonsOrder')(functi
         AND t.category_id = ${input.category_id}
     `);
   });
-  yield* background.enqueue(() =>
-    appRuntime.runPromise(
-      CACHE.lessons.category_lesson_list.refresh({ category_id: input.category_id })
-    )
-  );
+  yield* invalidateAndRefreshCache({
+    cache: CACHE.lessons.category_lesson_list,
+    params: { category_id: input.category_id }
+  });
   return { updated: true as const };
 });
 
@@ -188,7 +184,6 @@ export const addUpdateLessonCategory = Effect.fn('addUpdateLessonCategory')(func
   prev_category_id?: number;
   lesson_id: number;
 }) {
-  const background = yield* BackgroundWork;
   yield* dbTransaction('add_update_lesson_category', async (tx) => {
     await tx
       .update(text_lessons)
@@ -200,16 +195,16 @@ export const addUpdateLessonCategory = Effect.fn('addUpdateLessonCategory')(func
   });
 
   if (input.category_id) {
-    const category_id = input.category_id;
-    yield* background.enqueue(() =>
-      appRuntime.runPromise(CACHE.lessons.category_lesson_list.refresh({ category_id }))
-    );
+    yield* invalidateAndRefreshCache({
+      cache: CACHE.lessons.category_lesson_list,
+      params: { category_id: input.category_id }
+    });
   }
   if (input.prev_category_id) {
-    const category_id = input.prev_category_id;
-    yield* background.enqueue(() =>
-      appRuntime.runPromise(CACHE.lessons.category_lesson_list.refresh({ category_id }))
-    );
+    yield* invalidateAndRefreshCache({
+      cache: CACHE.lessons.category_lesson_list,
+      params: { category_id: input.prev_category_id }
+    });
   }
   return { added: true as const };
 });

--- a/src/api/routers/text_gestures.ts
+++ b/src/api/routers/text_gestures.ts
@@ -4,9 +4,7 @@ import { and, eq } from 'drizzle-orm';
 import { gesture_text_key_category_join, lesson_gestures, text_gestures } from '~/db/schema';
 import { dbRun, dbTransaction, type DbTransaction } from '~/effect/database';
 import { NotFoundError, BadRequestError } from '~/effect/errors';
-import { CACHE } from '~/effect/cache';
-import { BackgroundWork } from '~/effect/background';
-import { appRuntime } from '~/effect/runtime';
+import { CACHE, invalidateAndRefreshCache } from '~/effect/cache';
 import { FONT_FAMILIES, type FontFamily } from '~/state/font_list';
 import { GestureSchema } from '~/tools/stroke_data/types';
 import { t, protectedAdminProcedure, publicProcedure } from '~/api/trpc_init';
@@ -49,7 +47,6 @@ export const addTextGestureData = Effect.fn('addTextGestureData')(function* (inp
   fontSize: number;
   textCenterOffset: [number, number];
 }) {
-  const background = yield* BackgroundWork;
   const fontFamily = parseFontFamily(input.fontFamily);
   if (!fontFamily) {
     return yield* Effect.fail(
@@ -88,14 +85,13 @@ export const addTextGestureData = Effect.fn('addTextGestureData')(function* (inp
 
   if (!result.success) return result;
 
-  yield* background.enqueue(() =>
-    appRuntime.runPromise(
-      CACHE.gestures.gesture_data.refresh({
-        gesture_id: result.id,
-        gesture_uuid: result.uuid
-      })
-    )
-  );
+  yield* invalidateAndRefreshCache({
+    cache: CACHE.gestures.gesture_data,
+    params: {
+      gesture_id: result.id,
+      gesture_uuid: result.uuid
+    }
+  });
   return result;
 });
 
@@ -107,7 +103,6 @@ export const editTextGestureData = Effect.fn('editTextGestureData')(function* (i
   fontSize: number;
   textCenterOffset: [number, number];
 }) {
-  const background = yield* BackgroundWork;
   const fontFamily = parseFontFamily(input.fontFamily);
   if (!fontFamily) {
     return yield* Effect.fail(
@@ -135,14 +130,13 @@ export const editTextGestureData = Effect.fn('editTextGestureData')(function* (i
     );
   }
 
-  yield* background.enqueue(() =>
-    appRuntime.runPromise(
-      CACHE.gestures.gesture_data.refresh({
-        gesture_id: input.id,
-        gesture_uuid: input.uuid
-      })
-    )
-  );
+  yield* invalidateAndRefreshCache({
+    cache: CACHE.gestures.gesture_data,
+    params: {
+      gesture_id: input.id,
+      gesture_uuid: input.uuid
+    }
+  });
   return { updated: true as const };
 });
 
@@ -151,8 +145,6 @@ export const deleteTextGestureData = Effect.fn('deleteTextGestureData')(function
   uuid: string;
   script_id: number;
 }) {
-  const background = yield* BackgroundWork;
-
   const outcome = yield* dbTransaction('delete_text_gesture', async (tx) => {
     const [text_gesture_] = await tx
       .select({
@@ -218,21 +210,21 @@ export const deleteTextGestureData = Effect.fn('deleteTextGestureData')(function
   }
 
   if (outcome.lessons.length > 0) {
-    const refresh = Effect.forEach(
+    yield* Effect.forEach(
       outcome.lessons,
       ({ text_lesson_id }) =>
-        CACHE.lessons.text_lesson_info
-          .refresh({ lesson_id: text_lesson_id })
-          .pipe(
-            Effect.catch((error) =>
-              Effect.logWarning('lesson cache refresh failed', { text_lesson_id, error }).pipe(
-                Effect.asVoid
-              )
+        invalidateAndRefreshCache({
+          cache: CACHE.lessons.text_lesson_info,
+          params: { lesson_id: text_lesson_id }
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning('lesson cache refresh failed', { text_lesson_id, error }).pipe(
+              Effect.asVoid
             )
-          ),
+          )
+        ),
       { concurrency: 4 }
     );
-    yield* background.enqueue(() => appRuntime.runPromise(refresh));
   }
 
   yield* CACHE.gestures.gesture_data.delete({

--- a/src/api/routers/text_lessons.ts
+++ b/src/api/routers/text_lessons.ts
@@ -3,9 +3,7 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 import { lesson_gestures, text_lesson_words, text_lessons } from '~/db/schema';
 import { dbRun, dbTransaction, type DbTransaction } from '~/effect/database';
 import { BadRequestError, NotFoundError } from '~/effect/errors';
-import { CACHE } from '~/effect/cache';
-import { BackgroundWork } from '~/effect/background';
-import { appRuntime } from '~/effect/runtime';
+import { CACHE, invalidateAndRefreshCache } from '~/effect/cache';
 import { reorder_text_lesson_in_category, lesson_categories_router } from './lesson_categories';
 import { t, protectedAdminProcedure, publicProcedure } from '../trpc_init';
 import { runTrpcEffect } from '~/effect/run';
@@ -45,7 +43,6 @@ export const addTextLesson = Effect.fn('addTextLesson')(function* (input: {
     audio_id: number | null;
   }>;
 }) {
-  const background = yield* BackgroundWork;
   const { lang_id, base_word_script_id, audio_id, text } = input.lesson_info;
   const text_key = input.text_key.trim();
 
@@ -89,9 +86,10 @@ export const addTextLesson = Effect.fn('addTextLesson')(function* (input: {
     return yield* Effect.fail(BadRequestError.make({ message: 'Text lesson already exists' }));
   }
 
-  yield* background.enqueue(() =>
-    appRuntime.runPromise(CACHE.lessons.text_lesson_info.refresh({ lesson_id: outcome.result.id }))
-  );
+  yield* invalidateAndRefreshCache({
+    cache: CACHE.lessons.text_lesson_info,
+    params: { lesson_id: outcome.result.id }
+  });
 
   return {
     id: outcome.result.id,
@@ -110,7 +108,6 @@ export const updateTextLesson = Effect.fn('updateTextLesson')(function* (input: 
     audio_id: number | null;
   }>;
 }) {
-  const background = yield* BackgroundWork;
   const { id, audio_id, uuid } = input.lesson_info;
 
   const outcome = yield* dbTransaction('update_text_lesson', async (tx) => {
@@ -187,9 +184,10 @@ export const updateTextLesson = Effect.fn('updateTextLesson')(function* (input: 
     );
   }
 
-  yield* background.enqueue(() =>
-    appRuntime.runPromise(CACHE.lessons.text_lesson_info.refresh({ lesson_id: id }))
-  );
+  yield* invalidateAndRefreshCache({
+    cache: CACHE.lessons.text_lesson_info,
+    params: { lesson_id: id }
+  });
 
   return {
     updated: true as const,
@@ -201,7 +199,6 @@ export const deleteTextLesson = Effect.fn('deleteTextLesson')(function* (input: 
   id: number;
   uuid: string;
 }) {
-  const background = yield* BackgroundWork;
   const { id, uuid } = input;
 
   const outcome = yield* dbTransaction('delete_text_lesson', async (tx) => {
@@ -227,10 +224,10 @@ export const deleteTextLesson = Effect.fn('deleteTextLesson')(function* (input: 
   }
 
   if (outcome.category_id) {
-    const category_id = outcome.category_id;
-    yield* background.enqueue(() =>
-      appRuntime.runPromise(CACHE.lessons.category_lesson_list.refresh({ category_id }))
-    );
+    yield* invalidateAndRefreshCache({
+      cache: CACHE.lessons.category_lesson_list,
+      params: { category_id: outcome.category_id }
+    });
   }
   yield* CACHE.lessons.text_lesson_info.delete({ lesson_id: id });
 

--- a/src/effect/cache.ts
+++ b/src/effect/cache.ts
@@ -9,6 +9,9 @@ import { Database, type DbClient } from './database';
 const CACHE_EXPIRE_S = ms('30days') / 1000;
 
 type CacheEnv = RedisClient | BackgroundWork | Database;
+export type CacheRefreshOptions = {
+  deleteFirst?: boolean;
+};
 
 export interface CacheItem<TData, TParams> {
   key: (params: TParams) => string;
@@ -17,17 +20,25 @@ export interface CacheItem<TData, TParams> {
   delete: (params: TParams) => Effect.Effect<void, CacheError, RedisClient>;
   refresh: (
     params: TParams,
-    del?: boolean
+    options?: CacheRefreshOptions
   ) => Effect.Effect<void, CacheError, RedisClient | Database>;
 }
 
-export function createCache<TSchema extends z.ZodType, TData>(
-  keyPrefix: string,
-  schema: TSchema,
-  keyBuilder: (params: z.infer<TSchema>) => string,
-  fetchFn: (params: z.infer<TSchema>) => Effect.Effect<TData, CacheError, Database>,
+export interface CreateCacheConfig<TSchema extends z.ZodType, TData> {
+  keyPrefix: string;
+  schema: TSchema;
+  keyBuilder: (params: z.infer<TSchema>) => string;
+  fetch: (params: z.infer<TSchema>) => Effect.Effect<TData, CacheError, Database>;
+  ttl?: number;
+}
+
+export function createCache<TSchema extends z.ZodType, TData>({
+  keyPrefix,
+  schema,
+  keyBuilder,
+  fetch: fetchFn,
   ttl = CACHE_EXPIRE_S
-): CacheItem<TData, z.infer<TSchema>> {
+}: CreateCacheConfig<TSchema, TData>): CacheItem<TData, z.infer<TSchema>> {
   type TParams = z.infer<TSchema>;
 
   const validate = (params: TParams): TParams => schema.parse(params);
@@ -128,7 +139,10 @@ export function createCache<TSchema extends z.ZodType, TData>(
       });
     }),
 
-    refresh: Effect.fn('cache.refresh')(function* (params: TParams, del = true) {
+    refresh: Effect.fn('cache.refresh')(function* (
+      params: TParams,
+      { deleteFirst = true }: CacheRefreshOptions = {}
+    ) {
       const parsed = validate(params);
       const key = getKey(parsed);
       const generation = bumpGeneration(key);
@@ -139,7 +153,7 @@ export function createCache<TSchema extends z.ZodType, TData>(
         try: () =>
           enqueueKeyOp(key, async () => {
             if (currentGeneration(key) !== generation) return;
-            if (del) {
+            if (deleteFirst) {
               await Effect.runPromise(redis.del(key));
             }
             await Effect.runPromise(
@@ -155,6 +169,31 @@ export function createCache<TSchema extends z.ZodType, TData>(
 
   return cache;
 }
+
+export const invalidateAndRefreshCache = <TData, TParams>({
+  cache,
+  params
+}: {
+  cache: CacheItem<TData, TParams>;
+  params: TParams;
+}) =>
+  Effect.gen(function* () {
+    const background = yield* BackgroundWork;
+    const redis = yield* RedisClient;
+    const database = yield* Database;
+    yield* cache.delete(params);
+    yield* background.enqueue(() =>
+      Effect.runPromise(
+        cache
+          .refresh(params, { deleteFirst: false })
+          .pipe(
+            Effect.provideService(RedisClient, redis),
+            Effect.provideService(Database, database)
+          )
+      )
+    );
+  });
+
 const fromDb = <A>(operation: string, run: (client: DbClient) => Promise<A>) =>
   Effect.gen(function* () {
     const database = yield* Database;
@@ -166,13 +205,13 @@ const fromDb = <A>(operation: string, run: (client: DbClient) => Promise<A>) =>
 
 export const CACHE = {
   lessons: {
-    category_list: createCache(
-      'text_lesson_category_list',
-      z.object({
+    category_list: createCache({
+      keyPrefix: 'text_lesson_category_list',
+      schema: z.object({
         lang_id: z.int().positive()
       }),
-      ({ lang_id }) => `${lang_id}`,
-      ({ lang_id }) =>
+      keyBuilder: ({ lang_id }) => `${lang_id}`,
+      fetch: ({ lang_id }) =>
         fromDb('category_list', (db) =>
           db.query.lesson_categories.findMany({
             where: (tbl, { eq }) => eq(tbl.lang_id, lang_id),
@@ -180,14 +219,14 @@ export const CACHE = {
             orderBy: (lesson_categories, { asc }) => [asc(lesson_categories.order)]
           })
         )
-    ),
-    category_lesson_list: createCache(
-      'text_lesson_category_lessons_list',
-      z.object({
+    }),
+    category_lesson_list: createCache({
+      keyPrefix: 'text_lesson_category_lessons_list',
+      schema: z.object({
         category_id: z.int()
       }),
-      ({ category_id }) => `${category_id}`,
-      ({ category_id }) =>
+      keyBuilder: ({ category_id }) => `${category_id}`,
+      fetch: ({ category_id }) =>
         fromDb('category_lesson_list', (db) =>
           db.query.text_lessons.findMany({
             columns: {
@@ -201,14 +240,14 @@ export const CACHE = {
               and(eq(tbl.category_id, category_id), isNotNull(tbl.order))
           })
         )
-    ),
-    text_lesson_info: createCache(
-      'text_lesson_info',
-      z.object({
+    }),
+    text_lesson_info: createCache({
+      keyPrefix: 'text_lesson_info',
+      schema: z.object({
         lesson_id: z.int()
       }),
-      ({ lesson_id }) => `${lesson_id}`,
-      ({ lesson_id }) =>
+      keyBuilder: ({ lesson_id }) => `${lesson_id}`,
+      fetch: ({ lesson_id }) =>
         fromDb('text_lesson_info', (db) =>
           db.query.text_lessons.findFirst({
             where: (tbl, { eq }) => eq(tbl.id, lesson_id),
@@ -260,17 +299,17 @@ export const CACHE = {
             }
           })
         )
-    )
+    })
   },
   gestures: {
-    gesture_data: createCache(
-      'text_gesture_data',
-      z.object({
+    gesture_data: createCache({
+      keyPrefix: 'text_gesture_data',
+      schema: z.object({
         gesture_id: z.int(),
         gesture_uuid: z.uuid()
       }),
-      ({ gesture_id, gesture_uuid }) => `${gesture_id}:${gesture_uuid}`,
-      ({ gesture_id, gesture_uuid }) =>
+      keyBuilder: ({ gesture_id, gesture_uuid }) => `${gesture_id}:${gesture_uuid}`,
+      fetch: ({ gesture_id, gesture_uuid }) =>
         fromDb('gesture_data', (db) =>
           db.query.text_gestures.findFirst({
             where: (table, { eq, and }) =>
@@ -284,6 +323,6 @@ export const CACHE = {
             }
           })
         )
-    )
+    })
   }
 };

--- a/src/effect/errors.test.ts
+++ b/src/effect/errors.test.ts
@@ -4,8 +4,8 @@ import { z } from 'zod';
 import { DatabaseError, NotFoundError, StorageError, isKnownError } from './errors';
 import { RedisClient } from './redis';
 import { BackgroundWork } from './background';
-import { Database } from './database';
-import { createCache } from './cache';
+import { Database, type DbClient, type DbTransaction } from './database';
+import { createCache, invalidateAndRefreshCache } from './cache';
 
 describe('Effect infrastructure', () => {
   it.effect('maps StorageError tags', () =>
@@ -72,20 +72,70 @@ describe('cache refresh', () => {
         transaction: () => Effect.fail(DatabaseError.make({ operation: 'unused', cause: 'unused' }))
       });
 
-      const cache = createCache(
-        'test_list',
-        z.object({ lang_id: z.number() }),
-        ({ lang_id }) => `${lang_id}`,
-        () => Effect.succeed([{ id: 1, name: 'A' }])
-      );
+      const cache = createCache({
+        keyPrefix: 'test_list',
+        schema: z.object({ lang_id: z.number() }),
+        keyBuilder: ({ lang_id }) => `${lang_id}`,
+        fetch: () => Effect.succeed([{ id: 1, name: 'A' }])
+      });
 
       yield* cache
-        .refresh({ lang_id: 1 }, true)
+        .refresh({ lang_id: 1 }, { deleteFirst: true })
         .pipe(Effect.provide(TrackingRedis), Effect.provide(UnusedDb));
 
       expect(ops).toEqual(['del', 'set']);
       expect(stored).toEqual([{ id: 1, name: 'A' }]);
     }).pipe(Effect.provide(BackgroundWork.Test))
+  );
+
+  it.effect('invalidates synchronously before scheduling refresh-ahead', () =>
+    Effect.gen(function* () {
+      const ops: string[] = [];
+      const queuedWork: Array<() => Promise<unknown>> = [];
+      const TrackingRedis = Layer.succeed(RedisClient)({
+        get: () => Effect.succeed(null),
+        set: () => {
+          ops.push('set');
+          return Effect.succeed('OK');
+        },
+        del: () => {
+          ops.push('del');
+          return Effect.succeed(1);
+        }
+      });
+      const TestDatabase = Layer.succeed(Database)({
+        run: <A>(_operation: string, _run: (client: DbClient) => Promise<A>) =>
+          Effect.fail(DatabaseError.make({ operation: 'unused', cause: 'unused' })),
+        transaction: <A>(_operation: string, _run: (tx: DbTransaction) => Promise<A>) =>
+          Effect.fail(DatabaseError.make({ operation: 'unused', cause: 'unused' }))
+      });
+      const QueuedBackgroundWork = Layer.succeed(BackgroundWork)({
+        enqueue: (work) =>
+          Effect.sync(() => {
+            queuedWork.push(work);
+          })
+      });
+      const cache = createCache({
+        keyPrefix: 'test_list',
+        schema: z.object({ lang_id: z.number() }),
+        keyBuilder: ({ lang_id }) => `${lang_id}`,
+        fetch: () => Effect.succeed([{ id: 1, name: 'A' }])
+      });
+
+      yield* invalidateAndRefreshCache({
+        cache,
+        params: { lang_id: 1 }
+      }).pipe(
+        Effect.provide(TrackingRedis),
+        Effect.provide(TestDatabase),
+        Effect.provide(QueuedBackgroundWork)
+      );
+
+      expect(ops).toEqual(['del']);
+      expect(queuedWork).toHaveLength(1);
+      yield* Effect.promise(() => queuedWork[0]!());
+      expect(ops).toEqual(['del', 'set']);
+    })
   );
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic setup for the Effect repository during project preparation.
  * Improved cache refresh handling after audio, image, lesson, category, and text-gesture changes.

* **Bug Fixes**
  * Updated cache invalidation to occur immediately before refreshes are queued, helping users see current data sooner.
  * Preserved reliable background refreshes with bounded concurrency and warning-based failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->